### PR TITLE
fix(utils): scalingo stack does not exist anymore for a long time now

### DIFF
--- a/bin/utils
+++ b/bin/utils
@@ -92,13 +92,6 @@ python_sqlite3_check() {
   MIN_PYTHON_3="python-3.5.6"
   MIN_PYTHON_2="python-2.7.15"
 
-  # On the scalingo stack, sqlite is already installed no need to install it
-  # again
-  if [ "$STACK" = "scalingo" ] ; then
-    # 1 is false in bash
-    return 1
-  fi
-
   ( python2_check "$VERSION" && version_gte "$VERSION" "$MIN_PYTHON_2" ) \
     || ( python3_check "$VERSION" && version_gte "$VERSION" "$MIN_PYTHON_3" )
 }


### PR DESCRIPTION
`scalingo` is the previous name of `scalingo-14`. And `scalingo-14` is not supported anymore by this buildpack: 

https://github.com/Scalingo/python-buildpack/blob/779b523e371e379466f35d10c0d7d19e0db48502/bin/compile#L97-L104

Fix #10 