### PR TITLE
pipenv: upgrade Pipenv

### DIFF
--- a/bin/steps/pipenv
+++ b/bin/steps/pipenv
@@ -40,7 +40,7 @@ if [ ! "$SKIP_PIPENV_INSTALL" ]; then
             mcount "buildvar.PIP_EXTRA_INDEX_URL"
         fi
 
-        PIPENV_VERSION='2020.11.15'
+        PIPENV_VERSION='2022.10.25'
 
         # Install pipenv.
         # Due to weird old pip behavior and pipenv behavior, pipenv upgrades pip


### PR DESCRIPTION
## Description
We've ran into an issue with one of our Python app that causes Scalingo to fail the `pipenv install` step when rebuilding the app. I've tried and document it here:

https://gist.github.com/freesteph/de580c30f9545394cdc3666be52443a6

Using the commit in this PR fixes our issue, so we were wondering if you might be interested in upgrading pipenv too.

## Original commit message

The current version is two years old and is causing some of our packages installation to fail with messages such as:

  Installing dependencies from Pipfile.lock (63c834)...  error in
        <somepackage> setup command: 'extras_require' must be
        a dictionary whose values are strings or lists of strings
        containing valid project/version requirement specifiers.

With the relevant section in said package:

    extras_require={
        "Flask": ["Flask"],
        "dev": [
            "pytest",
            "pytest-flakes",
            "pytest-helpers-namespace",
        ],
    },

There is no clear violation of the expected format, however the package is installed from a Git source. That's all I've gathered at this point and I can't find a clear fix but this issue:

https://github.com/pypa/pipenv/issues/4309

Upgrading the pipenv version does fix the problem, so upgrade to the latest possible version and roll with it.
