### PR TITLE
Add support for pyproject

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -15,7 +15,7 @@
 BUILD_DIR=$1
 
 # Exit early if app is clearly not Python.
-if [ ! -f "$BUILD_DIR/requirements.txt" ] && [ ! -f "$BUILD_DIR/setup.py" ] && [ ! -f "$BUILD_DIR/Pipfile" ]; then
+if [ ! -f "$BUILD_DIR/requirements.txt" ] && [ ! -f "$BUILD_DIR/setup.py" ] && [ ! -f "$BUILD_DIR/Pipfile" ] && [ ! -f "$BUILD_DIR/pyproject.toml" ]; then
   exit 1
 fi
 


### PR DESCRIPTION
Fixes #80 

There is no more to do as a requirements.txt file containing `-e .` will be created and be compatible.

I think that if this is merged, scalingo documentation (at least this page https://doc.scalingo.com/languages/python/start should be updated)

Inspired from https://github.com/heroku/heroku-buildpack-python/pull/834
