### PR TITLE
fix: misc. fixes

### DIFF
--- a/bin/steps/pip-install
+++ b/bin/steps/pip-install
@@ -18,11 +18,7 @@ if [[ -z "$SKIP_PIP_INSTALL" ]]; then
 
     set +e
 
-    if [ ! -f "$BUILD_DIR/.scalingo/python/bin/pip" ]; then
-        exit 1
-    fi
-
-    /app/.scalingo/python/bin/pip install -r "$BUILD_DIR/requirements.txt" --exists-action=w --src="/app/.scalingo/src" --disable-pip-version-check --no-cache-dir --progress-bar off 2>&1 | tee "$WARNINGS_LOG" | cleanup | indent
+    /app/.scalingo/python/bin/pip install -r "$BUILD_DIR/requirements.txt" --exists-action=w --src="${HOME}/.scalingo/src" --disable-pip-version-check --no-cache-dir --progress-bar off 2>&1 | tee "$WARNINGS_LOG" | cleanup | indent
     PIP_STATUS="${PIPESTATUS[0]}"
     set -e
 
@@ -40,7 +36,7 @@ if [[ -z "$SKIP_PIP_INSTALL" ]]; then
     if [[ -n "$INSTALL_TEST" ]]; then
         if [[ -f requirements-test.txt ]]; then
             puts-step "Installing test dependencies…"
-            /app/.scalingo/python/bin/pip install -r "${1}/requirements-test.txt" --exists-action=w --src="./.scalingo/src" --disable-pip-version-check --no-cache-dir 2>&1 | cleanup | indent
+            /app/.scalingo/python/bin/pip install -r "${1}/requirements-test.txt" --exists-action=w --src="${HOME}/.scalingo/src" --disable-pip-version-check --no-cache-dir 2>&1 | cleanup | indent
         fi
     fi
 

--- a/bin/steps/pipenv
+++ b/bin/steps/pipenv
@@ -46,8 +46,6 @@ if [[ -f Pipfile ]]; then
         /app/.scalingo/python/bin/pipenv install --system --skip-lock --extra-pip-args='--src=/app/.scalingo/src' 2>&1 | indent
 
     else
-        pipenv-to-pip Pipfile.lock > requirements.txt
-        cp requirements.txt .scalingo/python/requirements-declared.txt
         meta_set "pipenv_has_lockfile" "true"
         puts-step "Installing dependencies with Pipenv ${PIPENV_VERSION}"
         /app/.scalingo/python/bin/pipenv install --system --deploy --extra-pip-args='--src=/app/.scalingo/src' 2>&1 | indent

--- a/bin/steps/python
+++ b/bin/steps/python
@@ -41,7 +41,11 @@ esac
 
 # The Python runtime archive filename is of form: 'python-X.Y.Z-ubuntu-22.04-amd64.tar.zst'
 # The Ubuntu version is calculated from `STACK` since it's faster than calling `lsb_release`.
-UBUNTU_VERSION="${STACK/scalingo-}.04"
+# Our approach is a bit different than Heroku's, because we want to be more
+# generic and keep compatibility with STACK values such as `heroku-22` or
+# `scalingo-22-minimal`:
+UBUNTU_VERSION="${STACK/-minimal}"
+UBUNTU_VERSION="${UBUNTU_VERSION: -2}.04"
 ARCH=$(dpkg --print-architecture)
 PYTHON_URL="${S3_BASE_URL}/${PYTHON_VERSION}-ubuntu-${UBUNTU_VERSION}-${ARCH}.tar.zst"
 


### PR DESCRIPTION
- remove calls to `pipenv-to-pip` script.
- fix the download URL to keep compatibility with stacks such as `heroku-xx` and `scalingo-xx-minimal`.
- use `$HOME` in `bin/steps/pip-install` for better understanding.