### PR TITLE
Fix SQLAlchemy profile.d script

### DIFF
--- a/vendor/python.sqlalchemy.sh
+++ b/vendor/python.sqlalchemy.sh
@@ -2,19 +2,19 @@
 
 set_sql_alchemy_url() {
 	local database_url="${1}"
-	local environment_variables_prefix="${2}"
+	local env_var="${2}"
 
-	if grep --ignore-case --silent "sqlachemy" \
+	if grep --ignore-case --silent --no-messages "sqlalchemy" \
 		"requirements.txt" "Pipfile" "pyproject.toml" \
-		&& test "${database_url}" =~ "postgres://"
+		&& [[ "${database_url}" =~ "postgres://" ]]
 	then
 		# Replace 'postgres://' with 'postgresql://':
 		local full_database_url="${database_url/postgres:\/\//postgresql://}"
 
-		eval "export ${environment_variables_prefix}_URL=${full_database_url}"
+		export "${env_var}=${full_database_url}"
 	fi
 }
 
 for database_url_variable in $( env | awk -F "=" '{print $1}' | grep "SCALINGO_POSTGRESQL_URL" ); do
-	set_sql_alchemy_url "$( eval echo "\$${database_url_variable}" )" "${database_url_variable//_URL/}_ALCHEMY"
+	set_sql_alchemy_url "$( eval echo "\$${database_url_variable}" )" "${database_url_variable//_URL/}_ALCHEMY_URL"
 done


### PR DESCRIPTION
- Handle `pyproject.toml`
- Better logic
- Remove a potentially dangerous `eval` call
- Better code readability

Tested with:

`pyproject.toml`:
```toml
[project]
name = "fastapi-sample"
version = "0.1.0"
description = "sample fastapi project"
readme = "README.md"
requires-python = ">=3.14"
dependencies = [
    "fastapi>=0.128.0",
    "jinja2>=3.1.6",
    "sqlalchemy>=2.0.47",
    "uvicorn>=0.40.0",
]
```

After deployment, in a one-off:

```bash
% printenv | grep ALCHEMY_URL
SCALINGO_POSTGRESQL_ALCHEMY_URL=postgresql://[REDACTED]
```

Fix #179 