### PR TITLE
feat(cgroupv2/web_concurrency) Add compatibility with cgroup v2 of automatic WEB_CONCURRENCY variable definition

### DIFF
--- a/vendor/WEB_CONCURRENCY.sh
+++ b/vendor/WEB_CONCURRENCY.sh
@@ -16,7 +16,8 @@
 # exit on error, have to use return not exit, and returning non-zero doesn't have an effect.
 
 function detect_memory_limit_in_mb() {
-	local memory_limit_file='/sys/fs/cgroup/memory/memory.limit_in_bytes'
+	local cgroup_root="${WEB_CONCURRENCY_CGROUP_ROOT:-/sys/fs/cgroup}"
+	local memory_limit_file="${cgroup_root}/memory/memory.limit_in_bytes"
 
 	# This memory limits file only exists on Heroku, or when using cgroups v1 (Docker < 20.10).
 	if [[ -f "${memory_limit_file}" ]]; then
@@ -26,6 +27,19 @@ function detect_memory_limit_in_mb() {
 		# bogus value of thousands of TB RAM when there is no container memory limit set.
 		if ((memory_limit_in_mb <= 1048576)); then
 			echo "${memory_limit_in_mb}"
+			return 0
+		fi
+	fi
+
+	memory_limit_file="${cgroup_root}/memory.max"
+
+	# cgroups v2 reports the memory limit in memory.max, or "max" when no limit is set.
+	if [[ -f "${memory_limit_file}" ]]; then
+		local memory_limit_in_bytes
+		memory_limit_in_bytes="$(cat "${memory_limit_file}")"
+
+		if [[ "${memory_limit_in_bytes}" != 'max' ]]; then
+			echo "$((memory_limit_in_bytes / 1048576))"
 			return 0
 		fi
 	fi


### PR DESCRIPTION
Fixes #198

```
++ detect_memory_limit_in_mb
++ local cgroup_root=/sys/fs/cgroup
++ local memory_limit_file=/sys/fs/cgroup/memory/memory.limit_in_bytes
++ [[ -f /sys/fs/cgroup/memory/memory.limit_in_bytes ]]
++ memory_limit_file=/sys/fs/cgroup/memory.max
++ [[ -f /sys/fs/cgroup/memory.max ]]
++ local memory_limit_in_bytes
+++ cat /sys/fs/cgroup/memory.max
++ memory_limit_in_bytes=536870912
++ [[ 536870912 != \m\a\x ]]
++ echo 512
++ return 0
+ available_memory_in_mb=512
++ nproc
+ cpu_cores=8
+ output 'Detected 512 MB available memory and 8 CPU cores.'
+ [[ one-off-9582 == web-* ]]
+ export DYNO_RAM=512
+ DYNO_RAM=512
+ [[ -v WEB_CONCURRENCY ]]
+ output 'Skipping automatic configuration of WEB_CONCURRENCY since it'\''s already set.'
+ [[ one-off-9582 == web-* ]]
+ return 0
./web_conrrency.sh: line 82: return: can only `return' from a function or sourced script
+ export WEB_CONCURRENCY_SET_BY=scalingo/python
+ WEB_CONCURRENCY_SET_BY=scalingo/python
+ minimum_memory_per_process_in_mb=256
+ (( available_memory_in_mb < minimum_memory_per_process_in_mb ))
+ max_concurrency_for_available_memory=2
+ max_concurrency_for_cpu_cores=17
+ (( max_concurrency_for_available_memory < max_concurrency_for_cpu_cores ))
+ export WEB_CONCURRENCY=2
+ WEB_CONCURRENCY=2
+ output 'Defaulting WEB_CONCURRENCY to 2 based on the available memory.'
+ [[ one-off-9582 == web-* ]]
```